### PR TITLE
fix: resolve memory leaks in config destroy and Go SDK wrapper

### DIFF
--- a/bcos-c-sdk/bcos_sdk_c_common.cpp
+++ b/bcos-c-sdk/bcos_sdk_c_common.cpp
@@ -216,6 +216,8 @@ void bcos_sdk_c_config_destroy(void* p)
     }
 
     bcos_sdk_c_free((void*)config->peers);
+    // Fix memory leak: free ssl_type field allocated by my_strdup in bcos_sdk_create_config
+    bcos_sdk_c_free((void*)config->ssl_type);
     bcos_sdk_c_free((void*)config);
 }
 

--- a/bindings/go/csdk/csdk_wrapper.go
+++ b/bindings/go/csdk/csdk_wrapper.go
@@ -152,6 +152,7 @@ func getContext(index unsafe.Pointer, delete bool) *CallbackChan {
 
 func NewSDK(groupID string, host string, port int, isSmSsl bool, privateKey []byte, disableSsl bool, tlsCaPath, tlsKeyPath, tlsCertPath, tlsSmEnKey, tlsSEnCert string) (*CSDK, error) {
 	cHost := C.CString(host)
+	defer C.free(unsafe.Pointer(cHost)) // Fix memory leak: free C string allocated by C.CString
 	cPort := C.int(port)
 	cIsSmSsl := C.int(0)
 	if isSmSsl {


### PR DESCRIPTION
## Summary
- Add missing `bcos_sdk_c_free(config->ssl_type)` in `bcos_sdk_c_config_destroy`
- Add `defer C.free(cHost)` in Go SDK wrapper's `NewSDK` function

## Changes
1. `bcos-c-sdk/bcos_sdk_c_common.cpp`: 
   - Add missing free for `ssl_type` field in config destroy
   - Leak size depends on ssl_type string length (e.g., 7 bytes for "sm_ssl")

2. `bindings/go/csdk/csdk_wrapper.go`:
   - Add defer to release C.CString memory for host parameter
   - Leak size depends on host string length (e.g., 14 bytes for "192.168.50.22")

## Test Plan
- [x] Verified memory leaks are fixed using valgrind/ASAN
- [x] Tested Go SDK client lifecycle without memory growth

Made with [Cursor](https://cursor.com)