### PR TITLE
fix: resolve memory leaks in config destroy and Go SDK wrapper

### DIFF
--- a/bcos-c-sdk/bcos_sdk_c_common.cpp
+++ b/bcos-c-sdk/bcos_sdk_c_common.cpp
@@ -216,6 +216,8 @@ void bcos_sdk_c_config_destroy(void* p)
     }
 
     bcos_sdk_c_free((void*)config->peers);
+    // 修复: 释放 ssl_type 字段，防止内存泄漏
+    bcos_sdk_c_free((void*)config->ssl_type);
     bcos_sdk_c_free((void*)config);
 }
 

--- a/bindings/go/csdk/csdk_wrapper.go
+++ b/bindings/go/csdk/csdk_wrapper.go
@@ -152,6 +152,7 @@ func getContext(index unsafe.Pointer, delete bool) *CallbackChan {
 
 func NewSDK(groupID string, host string, port int, isSmSsl bool, privateKey []byte, disableSsl bool, tlsCaPath, tlsKeyPath, tlsCertPath, tlsSmEnKey, tlsSEnCert string) (*CSDK, error) {
 	cHost := C.CString(host)
+	defer C.free(unsafe.Pointer(cHost)) // 修复: 释放 cHost，防止内存泄漏
 	cPort := C.int(port)
 	cIsSmSsl := C.int(0)
 	if isSmSsl {


### PR DESCRIPTION
## Summary

This PR fixes two memory leaks identified through Valgrind testing:

### 1. C SDK: bcos_sdk_c_common.cpp
- **Issue**: Missing bcos_sdk_c_free(config->ssl_type) in bcos_sdk_c_config_destroy()
- **Impact**: Memory leak of ssl_type string (e.g., 7 bytes for "sm_ssl")
- **Fix**: Added bcos_sdk_c_free((void*)config->ssl_type) before freeing the config struct

### 2. Go SDK: csdk_wrapper.go
- **Issue**: Missing C.free(cHost) after C.CString(host) in NewSDK()
- **Impact**: Memory leak of host string (e.g., 14 bytes for "192.168.50.22")
- **Fix**: Added defer C.free(unsafe.Pointer(cHost)) to release memory

## Test Plan
- [x] Verified with Valgrind memcheck
- [x] Before fix: 21 bytes definitely lost (14 + 7)
- [x] After fix: 0 bytes definitely lost

Made with [Cursor](https://cursor.com)